### PR TITLE
Update ppx to use module expression syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ lib/bs
 .merlin
 .bsb.lock
 node_modules
+/ppx

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -19,10 +19,11 @@
       "main-module": "LensesPpx"
     },
     {
-			"backend": "js",
-			"main-module": "Test"
-		}
+      "backend": "js",
+      "main-module": "Test"
+    }
   ],
   "refmt": 3,
+  "ppx-flags": ["./ppx"],
   "ocaml-dependencies": ["compiler-libs"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "requires": true,
+  "name": "lenses-ppx",
+  "version": "1.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "bsb-native": {
       "version": "4.0.7000",
       "resolved": "https://registry.npmjs.org/bsb-native/-/bsb-native-4.0.7000.tgz",
       "integrity": "sha512-RcmbmdwvGHnQBhxkz6B7+J0d4cTUhWDGIJ94DmjHDlwgH7cnzWTTKqASWkPiPTqlNFyZtQxZ9qTvAQrsE/iMpw==",
-      "dev": true,
       "requires": {
         "yauzl": "^2.9.1"
       }
@@ -14,14 +15,12 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -29,14 +28,12 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/src/LensesPpx.re
+++ b/src/LensesPpx.re
@@ -621,51 +621,36 @@ let createGadt = (~fields) => {
     ]),
 };
 
-let createModule = (~typeDef, ~typeName, ~fields, ~loc) =>
-  Str.module_(
-    ~loc,
-    Mb.mk(
-      ~loc=Location.none,
-      ~attrs=[],
-      {txt: String.capitalize(typeName) ++ "Lenses", loc: Location.none},
-      Mod.mk(
-        Pmod_structure([
-          typeDef,
-          createGadt(~fields),
-          createGetLens(~typeName, ~fields),
-          createSetLens(~typeName, ~fields),
-        ]),
-      ),
-    ),
+let createModule = (~typeDef, ~typeName, ~fields) =>
+  Mod.mk(
+    Pmod_structure([
+      typeDef,
+      createGadt(~fields),
+      createGetLens(~typeName, ~fields),
+      createSetLens(~typeName, ~fields),
+    ]),
   );
 
 let lensesMapper = _ => {
   ...default_mapper,
-  structure_item: (mapper, expr) =>
+  module_expr: (mapper, expr) =>
     switch (expr) {
     | {
-        pstr_desc:
-          Pstr_eval(
-            {
-              pexp_loc,
-              pexp_desc:
-                Pexp_extension((
-                  {txt: "lenses"},
-                  PStr([
+        pmod_desc:
+          Pmod_extension((
+            {txt: "lenses"},
+            PStr([
+              {
+                pstr_desc:
+                  Pstr_type([
                     {
-                      pstr_desc:
-                        Pstr_type([
-                          {
-                            ptype_name: {txt: typeName},
-                            ptype_kind: Ptype_record(fields),
-                          },
-                        ]),
+                      ptype_name: {txt: typeName},
+                      ptype_kind: Ptype_record(fields),
                     },
                   ]),
-                )),
-            },
-            _,
-          ),
+              },
+            ]),
+          )),
       } =>
       createModule(
         ~typeDef={
@@ -689,9 +674,8 @@ let lensesMapper = _ => {
         },
         ~typeName,
         ~fields,
-        ~loc=pexp_loc,
       )
-    | _ => default_mapper.structure_item(mapper, expr)
+    | _ => default_mapper.module_expr(mapper, expr)
     },
 };
 

--- a/test/Test.ml
+++ b/test/Test.ml
@@ -1,16 +1,14 @@
 module FormConfig = struct
-  [%lenses
-
-  type state = {
+  module State = [%lenses
+  type t = {
     email: string;
     age: int;
   };;
 ]
 end;;
 
-[%lenses
-
-  type user = {
+module User = [%lenses
+  type t = {
     email: string;
     age: int;
   };;

--- a/test/Test.re
+++ b/test/Test.re
@@ -1,10 +1,8 @@
-[%lenses]
-type state = {
-  email: string,
-  age: int,
-};
+module State = [%lenses
+  type state = {
+    email: string,
+    age: int,
+  }
+];
 
-let state: StateLenses.state = {
-  email: "",
-  age: 0,
-};
+let state: State.state = {email: "", age: 0};


### PR DESCRIPTION
Proposal to change the syntax to be less magical. 🧙‍♀️

For me, right now it's not clear what will be the name of the generated module. It's hard to spot newly created modules and IMO it's more natural to have something similar like [mhallin/graphql_ppx](https://github.com/mhallin/graphql_ppx) `[%graphql]`.