### PR TITLE
remove ppx-flags entry that was breaking install & build

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -24,6 +24,5 @@
     }
   ],
   "refmt": 3,
-  "ppx-flags": ["./ppx"],
   "ocaml-dependencies": ["compiler-libs"]
 }


### PR DESCRIPTION
#7 

looks like removing this line is fine and doesn't break anything
`yarn install` etc. work again in my project that is using lenses-ppx

